### PR TITLE
use named `guide` argument

### DIFF
--- a/vignettes/topological-analysis.Rmd
+++ b/vignettes/topological-analysis.Rmd
@@ -443,7 +443,7 @@ prt <- robust_topology %>%
   facet_grid(Topology  ~ Extinction) +
   scale_fill_gradient2(low = "blue", high = "red", mid = "white", 
                                 midpoint = rob_er, 
-                                guide_colorbar(title = "R")) +
+                                guide = guide_colorbar(title = "R")) +
   annotate(x = 15, y = .5, geom = "point", col = "black", size = 3) +
   annotate(x = 15, y = .55, geom = "text", label = "ER",
                     col = "black", size = 3) +


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break robber.

We have tried to harmonise scales and put the `name` argument first. Unfortunately, an unnamed guide argument in the vignette ended up in the wrong placed. This PR fixes this by using a named argument.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help robber get out a fix if necessary.